### PR TITLE
chore: a few installation fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: fmk
 channels:
     - conda-forge
-    - defaults
+    - nodefaults
     - gimli
 dependencies:
     - pygimli=1.3

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,3 @@ dependencies:
     - ipython
     - jupyter
     - pyvistaqt
-    - build

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
     - nodefaults
     - gimli
 dependencies:
-    - pygimli=1.3
+    - pygimli
     - pandas
     - obspy
     - pyyaml


### PR DESCRIPTION
A couple of fixes for making it easier to install:

- force _not_ using the defaults channel from anaconda
- remove the `build` package since it's not needed unless packaging for conda
- remove the pin for `gimli` since the pinned version is ~3 years old